### PR TITLE
chore: drop unconventional APP_ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@ NodeScript MongoDB Adapter can be configured with the following environment vari
 
 - **SWEEP_INACTIVE_TIMEOUT_MS** (default: 120_000) and **SWEEP_INTERVAL_MS** (default: 10_000) — adapter will periodically sweep the open connections and close them if they are inactive for specified amount of time.
 
-- **APP_ID** — arbitrary string added to Prometheus metrics as an `appId` label.
-
 ## Resource Requests & Limits
 
 MongoDB Adapter acts as a thin proxy between HTTP and MongoDB driver. When it comes to configure the compute resources it's best to keep the following in mind:

--- a/src/main/ConnectionManager.ts
+++ b/src/main/ConnectionManager.ts
@@ -3,7 +3,6 @@ import { config } from 'mesh-config';
 import { dep } from 'mesh-ioc';
 import { MongoClient } from 'mongodb';
 
-import { Env } from './Env.js';
 import { Metrics } from './Metrics.js';
 import { MongoConnection } from './util/MongoConnection.js';
 
@@ -26,7 +25,6 @@ export class ConnectionManager {
 
     @dep() private logger!: Logger;
     @dep() private metrics!: Metrics;
-    @dep() private env!: Env;
 
     private connectionMap = new Map<string, MongoConnection>();
     private running = false;
@@ -79,20 +77,17 @@ export class ConnectionManager {
             await client.connect();
             client.on('connectionCreated', () => {
                 this.metrics.connectionStats.incr(1, {
-                    appId: this.env.APP_ID,
                     type: 'connectionCreated'
                 });
             });
             client.on('connectionClosed', () => {
                 this.metrics.connectionStats.incr(1, {
-                    appId: this.env.APP_ID,
                     type: 'connectionClosed',
                 });
             });
             const connection = new MongoConnection(connectionKey, client);
             this.connectionMap.set(connectionKey, connection);
             this.metrics.connectionStats.incr(1, {
-                appId: this.env.APP_ID,
                 type: 'connect',
             });
             this.logger.info(`Mongo connection created`, { connectionKey });
@@ -100,7 +95,6 @@ export class ConnectionManager {
         } catch (error) {
             this.logger.error('Mongo connection failed', { error });
             this.metrics.connectionStats.incr(1, {
-                appId: this.env.APP_ID,
                 type: 'fail',
             });
             throw error;

--- a/src/main/Env.ts
+++ b/src/main/Env.ts
@@ -1,7 +1,0 @@
-import { config } from 'mesh-config';
-
-export class Env {
-
-    @config({ default: 'nodescript-mongodb-adapter' }) APP_ID!: string;
-
-}

--- a/src/main/Metrics.ts
+++ b/src/main/Metrics.ts
@@ -4,13 +4,11 @@ export class Metrics {
 
     @metric()
     connectionStats = new CounterMetric<{
-        appId: string;
         type: 'connect' | 'connectionCreated' | 'connectionClosed' | 'close' | 'fail';
     }>('nodescript_mongodb_adapter_connections', 'MongoDB adapter connections');
 
     @metric()
     methodLatency = new HistogramMetric<{
-        appId: string;
         domain: string;
         method: string;
         error?: string;

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -8,7 +8,6 @@ import { dep, Mesh } from 'mesh-ioc';
 
 import { AuthManager } from './AuthManager.js';
 import { ConnectionManager } from './ConnectionManager.js';
-import { Env } from './Env.js';
 import { Metrics } from './Metrics.js';
 import { AppHttpHandler } from './session/AppHttpHandler.js';
 import { AuthHandler } from './session/AuthHandler.js';
@@ -29,7 +28,6 @@ export class App extends BaseApp {
         this.mesh.service(HttpServer);
         this.mesh.service(Metrics);
         this.mesh.service(AuthManager);
-        this.mesh.service(Env);
         this.mesh.service(ConnectionManager);
         this.mesh.service(StandardHttpHandler);
         this.mesh.service(HttpCorsHandler);

--- a/src/main/session/MongoProtocolHandler.ts
+++ b/src/main/session/MongoProtocolHandler.ts
@@ -2,13 +2,11 @@ import { MongoProtocol, mongoProtocol } from '@nodescript/adapter-mongodb-protoc
 import { HttpProtocolHandler } from '@nodescript/http-server';
 import { dep } from 'mesh-ioc';
 
-import { Env } from '../Env.js';
 import { Metrics } from '../Metrics.js';
 import { MongoProtocolImpl } from './MongoProtocolImpl.js';
 
 export class MongoProtocolHandler extends HttpProtocolHandler<MongoProtocol> {
 
-    @dep() private env!: Env;
     @dep() private metrics!: Metrics;
 
     @dep() protocolImpl!: MongoProtocolImpl;
@@ -19,7 +17,6 @@ export class MongoProtocolHandler extends HttpProtocolHandler<MongoProtocol> {
         super();
         this.methodStats.on(stats => {
             this.metrics.methodLatency.addMillis(stats.latency, {
-                appId: this.env.APP_ID,
                 domain: stats.domain,
                 method: stats.method,
                 error: stats.error,


### PR DESCRIPTION
The APP_ID that gets passed to all application metrics is rather unconventional, especially given that there's tons of labels attached to the metrics when they are scraped (cluster, job, pod, etc, etc).