### PR TITLE
feat: add optional read preference

### DIFF
--- a/protocol/src/domains/MongoDomain.ts
+++ b/protocol/src/domains/MongoDomain.ts
@@ -4,6 +4,7 @@ import { MongoAggregate, MongoAggregateSchema } from '../schema/MongoAggregate.j
 import { MongoDocument, MongoDocumentSchema } from '../schema/MongoDocument.js';
 import { MongoFilter, MongoFilterSchema } from '../schema/MongoFilter.js';
 import { MongoProjection, MongoProjectionSchema } from '../schema/MongoProjection.js';
+import { MongoReadPreference, MongoReadPreferenceSchema } from '../schema/MongoReadPreference.js';
 import { MongoSort, MongoSortSchema } from '../schema/MongoSort.js';
 import { MongoUpdate, MongoUpdateSchema } from '../schema/MongoUpdate.js';
 
@@ -18,6 +19,7 @@ export interface MongoDomain {
         collection: string;
         filter: MongoFilter;
         projection?: MongoProjection;
+        readPreference?: MongoReadPreference;
     }): Promise<{
         document: MongoDocument | null;
     }>;
@@ -30,6 +32,7 @@ export interface MongoDomain {
         sort?: MongoSort;
         limit?: number;
         skip?: number;
+        readPreference?: MongoReadPreference;
     }): Promise<{
         documents: MongoDocument[];
     }>;
@@ -104,6 +107,7 @@ export interface MongoDomain {
         databaseUrl: string;
         collection: string;
         pipeline: MongoAggregate[];
+        readPreference?: MongoReadPreference;
     }): Promise<{
         documents: MongoDocument[];
     }>;
@@ -128,6 +132,10 @@ export const MongoDomain: DomainDef<MongoDomain> = {
                 filter: MongoFilterSchema.schema,
                 projection: {
                     ...MongoProjectionSchema.schema,
+                    optional: true,
+                },
+                readPreference: {
+                    ...MongoReadPreferenceSchema.schema,
                     optional: true,
                 },
             },
@@ -158,6 +166,10 @@ export const MongoDomain: DomainDef<MongoDomain> = {
                 },
                 skip: {
                     type: 'number',
+                    optional: true,
+                },
+                readPreference: {
+                    ...MongoReadPreferenceSchema.schema,
                     optional: true,
                 },
             },
@@ -276,13 +288,17 @@ export const MongoDomain: DomainDef<MongoDomain> = {
                     type: 'array',
                     items: MongoAggregateSchema.schema,
                 },
+                readPreference: {
+                    ...MongoReadPreferenceSchema.schema,
+                    optional: true,
+                },
             },
             returns: {
                 documents: {
                     type: 'array',
                     items: MongoDocumentSchema.schema,
                 }
-            }
+            },
         },
     },
     events: {},

--- a/protocol/src/index.ts
+++ b/protocol/src/index.ts
@@ -4,5 +4,6 @@ export * from './schema/MongoAggregate.js';
 export * from './schema/MongoDocument.js';
 export * from './schema/MongoFilter.js';
 export * from './schema/MongoProjection.js';
+export * from './schema/MongoReadPreference.js';
 export * from './schema/MongoSort.js';
 export * from './schema/MongoUpdate.js';

--- a/protocol/src/schema/MongoReadPreference.ts
+++ b/protocol/src/schema/MongoReadPreference.ts
@@ -1,0 +1,14 @@
+import { Schema } from 'airtight';
+
+export enum MongoReadPreference {
+    PRIMARY = 'primary',
+    PRIMARY_PREFERRED = 'primaryPreferred',
+    SECONDARY = 'secondary',
+    SECONDARY_PREFERRED = 'secondaryPreferred',
+    NEAREST = 'nearest',
+}
+
+export const MongoReadPreferenceSchema = new Schema<MongoReadPreference>({
+    type: 'string',
+    enum: Object.values(MongoReadPreference),
+});

--- a/src/main/session/MongoDomainImpl.ts
+++ b/src/main/session/MongoDomainImpl.ts
@@ -1,4 +1,4 @@
-import { MongoAggregate, MongoDocument, MongoDomain, MongoFilter, MongoProjection, MongoSort, MongoUpdate } from '@nodescript/adapter-mongodb-protocol';
+import { MongoAggregate, MongoDocument, MongoDomain, MongoFilter, MongoProjection, MongoReadPreference, MongoSort, MongoUpdate } from '@nodescript/adapter-mongodb-protocol';
 import { EJSON } from 'bson';
 import { dep } from 'mesh-ioc';
 
@@ -20,12 +20,14 @@ export class MongoDomainImpl implements MongoDomain {
         collection: string;
         filter: MongoFilter;
         projection?: MongoProjection;
+        readPreference?: MongoReadPreference;
     }): Promise<{ document: any }> {
         const connection = await this.getConnection(req.databaseUrl);
         const col = connection.db().collection(req.collection);
         const filter = EJSON.deserialize(req.filter);
         const document = await col.findOne(filter, {
             projection: req.projection,
+            readPreference: req.readPreference,
         });
         return {
             document: EJSON.serialize(document)
@@ -40,6 +42,7 @@ export class MongoDomainImpl implements MongoDomain {
         sort?: MongoSort;
         limit?: number;
         skip?: number;
+        readPreference?: MongoReadPreference;
     }): Promise<{ documents: any[] }> {
         const connection = await this.getConnection(req.databaseUrl);
         const col = connection.db().collection(req.collection);
@@ -49,6 +52,7 @@ export class MongoDomainImpl implements MongoDomain {
             sort: req.sort,
             limit: req.limit,
             skip: req.skip,
+            readPreference: req.readPreference,
         }).toArray();
         return {
             documents: EJSON.serialize(documents) as any[]
@@ -185,6 +189,7 @@ export class MongoDomainImpl implements MongoDomain {
         databaseUrl: string;
         collection: string;
         pipeline: MongoAggregate[];
+        readPreference?: MongoReadPreference;
     }): Promise<{
         documents: any[];
     }> {
@@ -193,6 +198,7 @@ export class MongoDomainImpl implements MongoDomain {
         const pipeline = EJSON.deserialize(req.pipeline);
         const documents = await col.aggregate(pipeline, {
             allowDiskUse: true,
+            readPreference: req.readPreference,
         }).toArray();
         return {
             documents: EJSON.serialize(documents) as any[]


### PR DESCRIPTION
Allows nodes to send optional `readPreference` (btw default is `primary` according to [docs](https://www.mongodb.com/docs/manual/core/read-preference/))