### PR TITLE
feat: track result size during findmany execution

### DIFF
--- a/src/main/global/CustomErrorHandler.ts
+++ b/src/main/global/CustomErrorHandler.ts
@@ -30,3 +30,15 @@ export class WrappedMongoError extends Error {
     }
 
 }
+
+export class MemoryLimitError extends Error {
+
+    override name = 'MemoryLimitError';
+    status = 500;
+    details: any;
+
+    constructor(message: string) {
+        super(message);
+    }
+
+}


### PR DESCRIPTION
symptom: users are getting vague errors surrounding large queries: `TypeError: Failed to Fetch`

problem: when a query is executed that results in large numbers of documents / very large documents being collated, `.toArray()` loads all docs into memory at once, and javascript heap collapses. This error can't be caught at this point, so a less generic error can't be provided.

proposed solution: implement `MEMORY_LIMIT` config (currently somewhat arbitrarily set at 100MB, it's just where things started getting slow for me locally before actually crashing), execute in batches, when collected doc size exceeds the limit, throw an error providing more accurate feedback.

Disadvantages of doing this is that it is slower than `.toArray`, and more complex.
